### PR TITLE
Refactor(atoms):  arrow to chevron

### DIFF
--- a/packages/shared/styles/classes/_mixins.scss
+++ b/packages/shared/styles/classes/_mixins.scss
@@ -29,5 +29,10 @@
         }
       }
     }
+    &#{$name} {
+      @for $i from 0 to length($properties) {        
+          #{nth($properties, $i + 1)}: $space;
+      }
+    }
   }
 }

--- a/packages/shared/styles/classes/_mixins.scss
+++ b/packages/shared/styles/classes/_mixins.scss
@@ -29,10 +29,10 @@
         }
       }
     }
-    &#{$name} {
-      @for $i from 0 to length($properties) {        
-          #{nth($properties, $i + 1)}: $space;
-      }
-    }
+    // &#{$name} {
+    //   @for $i from 0 to length($properties) {        
+    //       #{nth($properties, $i + 1)}: $space;
+    //   }
+    // }
   }
 }

--- a/packages/shared/styles/components/atoms/SfArrow.scss
+++ b/packages/shared/styles/components/atoms/SfArrow.scss
@@ -7,7 +7,7 @@
   --button-transition: background 150ms linear;
   --icon-width: 1.5rem;
   --icon-height: 0.75rem;
-  --icon-color: var(--c-dark);
+  // --icon-color: var(--c-dark);
   --button-box-shadow: 0px 4px 4px var(--c-black);
   --box-shadow-transition-opacity-duration: 150ms;
   display: flex;

--- a/packages/shared/styles/components/atoms/SfBadge.scss
+++ b/packages/shared/styles/components/atoms/SfBadge.scss
@@ -6,11 +6,11 @@
   min-width: var(--badge-min-width);
   height: var(--badge-height);
   min-height: var(--badge-min-height);
-  padding: var(--badge-padding, var(--spacer-xs) var(--spacer-sm));
-  background: var(--badge-background, var(--c-primary));
+  // padding: var(--badge-padding, var(--spacer-xs) var(--spacer-sm));
+  // background: var(--badge-background, var(--c-primary));
   border: var(--badge-border);
   border-radius: var(--badge-border-radius);
-  color: var(--badge-color, var(--c-white));
+  // color: var(--badge-color, var(--c-white));
   text-align: var(--badge-text-align, center);
   @include font(
     --badge-font,

--- a/packages/shared/styles/components/atoms/SfBreadcrumbs.scss
+++ b/packages/shared/styles/components/atoms/SfBreadcrumbs.scss
@@ -27,7 +27,7 @@
       1.6,
       var(--font-family-secondary)
     );
-    --link-color: var(--c-text-muted);
+    // --link-color: var(--c-text-muted);
     --link-text-decoration: none;
     &:hover {
       --link-color: var(--c-text);

--- a/packages/shared/styles/components/atoms/SfBullets.scss
+++ b/packages/shared/styles/components/atoms/SfBullets.scss
@@ -3,7 +3,7 @@
   box-sizing: border-box;
   width: var(--bullet-width, var(--bullet-size, 0.5rem));
   height: var(--bullet-height, var(--bullet-size, 0.5rem));
-  margin: var(--bullet-margin, var(--spacer-2xs));
+  // margin: var(--bullet-margin, var(--spacer-2xs));
   border-radius: var(--bullet-border-radius, 100%);
   background: var(--bullet-background, var(--c-gray));
   transition: transform 150ms linear, box-shadow 150ms linear;

--- a/packages/shared/styles/components/atoms/SfButton.scss
+++ b/packages/shared/styles/components/atoms/SfButton.scss
@@ -1,5 +1,6 @@
 @import "../../helpers";
 .sf-button {
+  --link-color: var(--button-color, var(--c-light-variant));
   box-sizing: border-box;
   position: relative;
   width: var(--button-size, var(--button-width));
@@ -42,6 +43,9 @@
         --button-background: #{$variant};
       }
     }
+  }
+  &.sf-link { 
+    --button-width: var(--spacer-3xl);
   }
   &:hover {
     --button-box-shadow-opacity: 0.25;

--- a/packages/shared/styles/components/atoms/SfButton.scss
+++ b/packages/shared/styles/components/atoms/SfButton.scss
@@ -1,6 +1,6 @@
 @import "../../helpers";
 .sf-button {
-  --link-color: var(--button-color, var(--c-light-variant));
+  // --link-color: var(--button-color, var(--c-light-variant));
   box-sizing: border-box;
   position: relative;
   width: var(--button-size, var(--button-width));
@@ -8,8 +8,8 @@
   display: var(--button-display, flex);
   align-items: center;
   justify-content: center;
-  padding: var(--button-padding, var(--spacer-sm) calc(var(--spacer-sm) * 2));
-  color: var(--button-color, var(--c-light-variant));
+  // padding: var(--button-padding, var(--spacer-sm) calc(var(--spacer-sm) * 2));
+  // color: var(--button-color, var(--c-light-variant));
   background: var(--button-background, var(--c-primary));
   transition: var(--button-transition);
   text-transform: var(--button-text-transform, uppercase);
@@ -20,9 +20,9 @@
   @include font(
     --button-font,
     var(--font-semibold),
-    var(--font-base),
+    var(),
     1.2,
-    var(--font-family-secondary)
+    var()
   );
   @include border(--button-border, 0, solid, var(--c-primary));
   @include box-shadow(

--- a/packages/shared/styles/components/atoms/SfCheckbox.scss
+++ b/packages/shared/styles/components/atoms/SfCheckbox.scss
@@ -32,14 +32,14 @@
   }
   &__label {
     flex: 1;
-    margin: var(--checkbox-label-margin, 0 0 0 var(--spacer-sm));
-    color: var(--checkbox-label-color, var(--_c-dark-secondary));
+    // margin: var(--checkbox-label-margin, 0 0 0 var(--spacer-sm));
+    // color: var(--checkbox-label-color, var(--_c-dark-secondary));
     @include font(
       --checkbox-font,
       var(--font-normal),
-      var(--font-sm),
+      var(),
       1.6,
-      var(--font-family-secondary)
+      var()
     );
   }
   &--is-active {

--- a/packages/shared/styles/components/organisms/SfHero.scss
+++ b/packages/shared/styles/components/organisms/SfHero.scss
@@ -51,6 +51,15 @@
   &--align-right {
     --hero-item-justify-content: flex-end;
   }
+  &--position-bg-top-right {
+    background-position: top right;
+  }
+  &--position-bg-bottom-right {
+    background-position: bottom right;
+  }
+  &--position-bg-bottom-left {
+    background-position: bottom left;
+  }
   @include for-desktop {
     --hero-item-height: 36.625rem;
     --hero-item-padding: var(--spacer-2xl);

--- a/packages/shared/styles/components/organisms/SfHero.scss
+++ b/packages/shared/styles/components/organisms/SfHero.scss
@@ -87,7 +87,11 @@
     justify-content: var(--hero-controls-justify-content, space-between);
     width: var(--hero-controls-width, 100%);
     padding: var(--hero-controls-padding, 0 var(--spacer-sm));
-  }
+    pointer-events: none;
+    &__arrow {
+      pointer-events: all;
+    }
+   }
   &__bullets {
     position: absolute;
     bottom: var(--hero-bullets-bottom, var(--spacer-xl));

--- a/packages/shared/styles/components/organisms/SfProductCard.scss
+++ b/packages/shared/styles/components/organisms/SfProductCard.scss
@@ -123,8 +123,8 @@
     --product-card-padding: var(--spacer-sm);
     --product-card-title-margin: var(--spacer-xl) 0 0 0;
     --product-card-transition: box-shadow 150ms ease-in-out;
-    --product-card-wishlist-icon-top: var(--spacer-lg);
-    --product-card-wishlist-icon-right: var(--spacer-lg);
+    --product-card-wishlist-icon-top: var(--spacer-base);
+    --product-card-wishlist-icon-right: var(--spacer-base);
     --product-card-wishlist-icon-opacity: 0;
     --product-card-add-button-display: flex;
   }

--- a/packages/vue/src/components/atoms/SfArrow/SfArrow.vue
+++ b/packages/vue/src/components/atoms/SfArrow/SfArrow.vue
@@ -6,7 +6,7 @@
         size="1.5rem"
         icon="arrow_left"
         aria-hidden="true"
-        class="sf-arrow__icon"
+        class="sf-arrow__icon text-color-black-primary"
       />
     </slot>
   </SfButton>

--- a/packages/vue/src/components/atoms/SfBadge/SfBadge.vue
+++ b/packages/vue/src/components/atoms/SfBadge/SfBadge.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sf-badge">
+  <div class="sf-badge pdy-xs pdxsm--d bg-color-primary txt-color-base">
     <!--@slot Use this slot to place content inside the badge-->
     <slot />
   </div>

--- a/packages/vue/src/components/atoms/SfBadge/SfBadge.vue
+++ b/packages/vue/src/components/atoms/SfBadge/SfBadge.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sf-badge pdy-xs pdxsm--d bg-color-primary txt-color-base">
+  <div class="sf-badge pdyxs--d pdxsm--d bg-color-primary txt-color-base">
     <!--@slot Use this slot to place content inside the badge-->
     <slot />
   </div>

--- a/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.vue
+++ b/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.vue
@@ -10,7 +10,9 @@
         <template v-if="last !== i">
           <!-- @slot Custom markup for previous pages (binds `breadcrumb` object) -->
           <slot name="link" v-bind="{ breadcrumb }">
-            <SfLink :link="breadcrumb.link" class="sf-breadcrumbs__breadcrumb"
+            <SfLink
+              :link="breadcrumb.link"
+              class="sf-breadcrumbs__breadcrumb txt-color-muted-primary"
               >{{ breadcrumb.text }}
             </SfLink>
           </slot>

--- a/packages/vue/src/components/atoms/SfBullets/SfBullets.vue
+++ b/packages/vue/src/components/atoms/SfBullets/SfBullets.vue
@@ -6,7 +6,7 @@
         <li :key="index">
           <SfButton
             :aria-label="'Go to slide ' + (index + 1)"
-            class="sf-button--pure sf-bullet"
+            class="sf-button--pure sf-bullet mr2xs--d"
             @click="go(index)"
           ></SfButton>
         </li>
@@ -17,7 +17,7 @@
       <li>
         <SfButton
           aria-label="Current slide"
-          class="sf-button--pure sf-bullet sf-bullet--active"
+          class="sf-button--pure sf-bullet sf-bullet--active mr2xs--d"
         ></SfButton>
       </li>
     </slot>
@@ -31,7 +31,7 @@
         <li :key="inactiveLeft + 1 + index">
           <SfButton
             :aria-label="'Go to slide ' + (inactiveLeft + 2 + index)"
-            class="sf-button--pure sf-bullet"
+            class="sf-button--pure sf-bullet mr2xs--d"
             @click="go(inactiveLeft + 1 + index)"
           ></SfButton>
         </li>

--- a/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
@@ -37,11 +37,58 @@ storiesOf("Atoms|Button", module)
       disabled: {
         default: boolean("disabled", false, "Props"),
       },
+      link: {
+        default: text("link", "", "Props"),
+      }
     },
     components: { SfButton },
     template: `<SfButton
       :class="customClass"
-      :disabled="disabled">
+      :disabled="disabled"
+      :nativeButton="nativeButton"
+      :link="link">
+      {{customLabel}}
+    </SfButton>`,
+  }))
+  .add("Link as button", () => ({
+    props: {
+      customClass: {
+        default: options(
+          "CSS modifiers",
+          {
+            "sf-button--outline": "sf-button--outline",
+            "sf-button--underlined": "sf-button--underlined",
+            "sf-button--text": "sf-button--text",
+            "sf-button--full-width": "sf-button--full-width",
+            "sf-button--pure": "sf-button--pure",
+            "color-primary": "color-primary",
+            "color-secondary": "color-secondary",
+            "color-warning": "color-warning",
+            "color-danger": "color-danger",
+            "color-info": "color-info",
+            "color-success": "color-success",
+          },
+          "",
+          { display: "multi-select" },
+          "CSS Modifiers"
+        ),
+      },
+      customLabel: {
+        default: text("default", "Shop now", "Slots"),
+      },
+      disabled: {
+        default: boolean("disabled", false, "Props"),
+      },
+      link: {
+        default: text("link", "https://www.storefrontui.io/", "Props"),
+      }
+    },
+    components: { SfButton },
+    template: `<SfButton
+      :class="customClass"
+      :disabled="disabled"
+      :nativeButton="nativeButton"
+      :link="link">
       {{customLabel}}
     </SfButton>`,
   }));

--- a/packages/vue/src/components/atoms/SfButton/SfButton.vue
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.vue
@@ -1,19 +1,25 @@
 <template>
-  <button
+  <component
+    :is="tag"
     v-focus
     class="sf-button"
     v-bind="$attrs"
     :disabled="disabled"
+    :link="link"
     v-on="$listeners"
   >
     <!--@slot Use this slot to place content inside the button.-->
     <slot />
-  </button>
+  </component>
 </template>
 <script>
 import { focus } from "../../../utilities/directives";
+import SfLink from "../SfLink/SfLink.vue";
 export default {
   name: "SfButton",
+  components: {
+    SfLink,
+  },
   directives: {
     focus,
   },
@@ -24,6 +30,18 @@ export default {
     disabled: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * Link for "a" tag, when empty it is button.
+     */
+    link: {
+      type: [String, Object],
+      default: "",
+    },
+  },
+  computed: {
+    tag() {
+      return this.link ? "SfLink" : "button";
     },
   },
 };

--- a/packages/vue/src/components/atoms/SfButton/SfButton.vue
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.vue
@@ -2,7 +2,7 @@
   <component
     :is="tag"
     v-focus
-    class="sf-button"
+    class="sf-button pdysm--d pdxlg--d font-secondary txt-base txt-color-base"
     v-bind="$attrs"
     :disabled="disabled"
     :link="link"

--- a/packages/vue/src/components/atoms/SfCheckbox/SfCheckbox.vue
+++ b/packages/vue/src/components/atoms/SfCheckbox/SfCheckbox.vue
@@ -29,7 +29,12 @@
       </slot>
       <!-- @slot Custom label markup -->
       <slot name="label" v-bind="{ label, isChecked, disabled }">
-        <div v-if="label" class="sf-checkbox__label">{{ label }}</div>
+        <div
+          v-if="label"
+          class="sf-checkbox__label mrlsm--d font-secondary txt-sm txt-color-dark-secondary"
+        >
+          {{ label }}
+        </div>
       </slot>
     </label>
   </div>

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
@@ -181,8 +181,8 @@ export default {
       return this.options[this.index].html;
     },
     maxHeight() {
-      if (!this.size) return;
-      return `${this.optionHeight * this.size}px`;
+      if (!this.options.length) return;
+      return `${this.optionHeight * this.options.length}px`;
     },
     isActive() {
       return this.open;
@@ -197,7 +197,9 @@ export default {
       handler: function (visible) {
         if (visible) {
           this.$nextTick(() => {
-            this.optionHeight = this.$slots.default[0].elm.offsetHeight;
+            if (this.$slots.default) {
+              this.optionHeight = this.$slots.default[0].elm.offsetHeight;
+            }
           });
         }
       },
@@ -205,20 +207,14 @@ export default {
   },
   created: function () {},
   mounted: function () {
-    const options = [];
-    const indexes = {};
-    if (!this.$slots.default) return;
-    this.$on("update", this.update);
-    this.$slots.default.forEach((slot, index) => {
-      if (!slot.tag) return;
-      options.push({
-        ...slot.componentOptions.propsData,
-        html: slot.elm.innerHTML,
-      });
-      indexes[JSON.stringify(slot.componentOptions.propsData.value)] = index;
-    });
-    this.options = options;
-    this.indexes = indexes;
+    this.addOptionsAndIndexes();
+  },
+  updated() {
+    if (this.$slots.default) {
+      if (this.$slots.default.length > this.options.length) {
+        this.addOptionsAndIndexes();
+      }
+    }
   },
   beforeDestroy: function () {
     this.$off("update", this.update);
@@ -226,6 +222,22 @@ export default {
   methods: {
     update(index) {
       this.index = index;
+    },
+    addOptionsAndIndexes() {
+      const options = [];
+      const indexes = {};
+      if (!this.$slots.default) return;
+      this.$on("update", this.update);
+      this.$slots.default.forEach(({ tag, componentOptions, elm }, index) => {
+        if (!tag) return;
+        options.push({
+          ...componentOptions.propsData,
+          html: elm.innerHTML,
+        });
+        indexes[JSON.stringify(componentOptions.propsData.value)] = index;
+      });
+      this.options = options;
+      this.indexes = indexes;
     },
     move(payload) {
       const optionsLength = this.options.length;

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
@@ -19,7 +19,6 @@
     @keyup.up="move(-1)"
     @keyup.down="move(1)"
     @keyup.enter="enter($event)"
-    v-on="$listeners"
   >
     <div style="position: relative;">
       <div
@@ -27,6 +26,7 @@
         v-focus
         tabindex="0"
         class="sf-select__selected sf-select-option"
+        v-on="$listeners"
         v-html="html"
       ></div>
       <slot name="label">

--- a/packages/vue/src/components/organisms/SfHero/SfHero.stories.js
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.stories.js
@@ -67,6 +67,7 @@ storiesOf("Organisms|Hero", module)
           :background="background"
       />
       <SfHeroItem
+          :class="customClass"
           title="Colorful summer dresses are already in store"
           subtitle="Summer Collection 2019"
           button-text="Learn more"
@@ -136,6 +137,7 @@ storiesOf("Organisms|Hero", module)
         :background="background"
       />
       <SfHeroItem
+          :class="customClass"
           title="Colorful summer dresses are already in store"
           subtitle="Summer Collection 2019"
           button-text="Learn more"
@@ -205,6 +207,7 @@ storiesOf("Organisms|Hero", module)
           :background="background"
       />
       <SfHeroItem
+          :class="customClass"
           title="Colorful summer dresses are already in store"
           subtitle="Summer Collection 2019"
           button-text="Learn more"
@@ -274,6 +277,7 @@ storiesOf("Organisms|Hero", module)
           :background="background"
       />
       <SfHeroItem
+          :class="customClass"
           title="Colorful summer dresses are already in store"
           subtitle="Summer Collection 2019"
           button-text="Learn more"

--- a/packages/vue/src/components/organisms/SfHero/SfHero.vue
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.vue
@@ -13,7 +13,7 @@
       <slot name="prev" v-bind="{ go: () => go('prev') }">
         <div @click="go('prev')">
           <SfArrow
-            class="sf-arrow sf-arrow--transparent"
+            class="sf-arrow sf-arrow--transparent sf-hero__controls__arrow"
             aria-label="previous"
           />
         </div>
@@ -22,7 +22,7 @@
       <slot name="next" v-bind="{ go: () => go('next') }">
         <div @click="go('next')">
           <SfArrow
-            class="sf-arrow sf-arrow--right sf-arrow--transparent"
+            class="sf-arrow sf-arrow--right sf-arrow--transparent sf-hero__controls__arrow"
             aria-label="next"
           />
         </div>

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -35,6 +35,20 @@
           >{{ badgeLabel }}</SfBadge
         >
       </slot>
+      <SfButton
+        v-if="wishlistIcon !== false"
+        :aria-label="`${ariaLabel} ${title}`"
+        :class="wishlistIconClasses"
+        @click="toggleIsOnWishlist"
+      >
+        <slot name="wishlist-icon" v-bind="{ currentWishlistIcon }">
+          <SfIcon
+            :icon="currentWishlistIcon"
+            size="22px"
+            data-test="sf-wishlist-icon"
+          />
+        </slot>
+      </SfButton>
       <template v-if="showAddToCartButton">
         <slot
           name="add-to-cart"
@@ -83,20 +97,6 @@
         </h3>
       </SfLink>
     </slot>
-    <SfButton
-      v-if="wishlistIcon !== false"
-      :aria-label="`${ariaLabel} ${title}`"
-      :class="wishlistIconClasses"
-      @click="toggleIsOnWishlist"
-    >
-      <slot name="wishlist-icon" v-bind="{ currentWishlistIcon }">
-        <SfIcon
-          :icon="currentWishlistIcon"
-          size="22px"
-          data-test="sf-wishlist-icon"
-        />
-      </slot>
-    </SfButton>
     <slot name="price" v-bind="{ specialPrice, regularPrice }">
       <SfPrice
         v-if="regularPrice"


### PR DESCRIPTION
# Related issue
#1297

# Scope of work
Refactor atoms arrow to chevron to use utility classes

I left css propertities commented out which replaced to utility class to know how many of them was changed.

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed

  
